### PR TITLE
feat(api): added endpoints for pump

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,56 @@
+from flask import Flask, Response
+import json
+
+app = Flask('app')
+
+@app.route('/', methods=['GET'])
+def home():
+  res = {
+    'apis': [
+      {
+        'path': '/pump',
+        'method': 'GET',
+        'purpose': 'Returns current status of pump'
+      },
+      {
+        'path': '/pump/on',
+        'method': 'POST',
+        'purpose': 'Turns on the pump'
+      },
+      {
+        'path': '/pump/off',
+        'method': 'POST',
+        'purpose': 'Turns off the pump'
+      },
+      {
+        'path': '/led',
+        'method': 'GET',
+        'purpose': 'Returns current status of led'
+      },
+      {
+        'path': '/led/on',
+        'method': 'POST',
+        'purpose': 'Turns on the LED at 100%'
+      },
+      {
+        'path': '/led/off',
+        'method': 'POST',
+        'purpose': 'Turns off the LED'
+      },
+      {
+        'path': '/led/adjust',
+        'method': 'POST',
+        'purpose': 'Adjust the LED to given percentage'
+      }
+    ]
+  }
+  return build_response(res, 200)
+
+def build_response(res, status):
+  r = Response(response=json.dumps(res), status=status, mimetype='text/json')
+  r.headers['Content-Type'] = 'text/json; charset=utf-8'
+  return r
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=80)

--- a/main.py
+++ b/main.py
@@ -3,10 +3,11 @@ import os
 from threading import Thread
 from flask import Flask, request, jsonify
 from sensors.led import LED
+from sensors.pump import Pump
 
 app = Flask('app')
 lights = None
-
+pump = Pump()
 
 @app.route('/ping', methods=['GET', 'POST'])
 def ping():
@@ -56,6 +57,21 @@ def led():
             'page': ''
         }
     return jsonify(res)
+
+@app.route('/pump', methods=['GET'])
+def pump_status():
+    res = {'pump_status': pump.status(), 'code': 200}
+    return jsonify(res)
+
+@app.route('/pump/on', methods=['POST'])
+def pump_on():
+    pump.turn_on()
+    return pump_status()
+
+@app.route('/pump/off', methods=['POST'])
+def pump_off():
+    pump.turn_off()
+    return pump_status()
 
 
 # TODO: Implement waterlevel endpoints #29

--- a/sensors/led.py
+++ b/sensors/led.py
@@ -2,7 +2,7 @@
 import pigpio
 import time
 
-from config import CHANNEL_LED, FREQ_LED
+from .config import CHANNEL_LED, FREQ_LED
 
 class LED:
     # 0 => off

--- a/sensors/pump.py
+++ b/sensors/pump.py
@@ -3,7 +3,7 @@ import RPi.GPIO as GPIO
 import time
 import os
 
-from config import CHANNEL_WATER_PUMP, FREQ_WATER_PUMP, MAX_DUTY_PUMP, INIT_DUTY_WATER_PUMP, LAST_SECS_WATER_PUMP
+from .config import CHANNEL_WATER_PUMP, FREQ_WATER_PUMP, MAX_DUTY_PUMP, INIT_DUTY_WATER_PUMP, LAST_SECS_WATER_PUMP
 
 class Pump:
     PUMP_STATUS = 0
@@ -18,6 +18,9 @@ class Pump:
         print('Water Pump stopped at channel {}, GPIO has been cleaned up'.format(CHANNEL_WATER_PUMP))
         print('----------------------------------------')
         # read_ina219()
+
+    def status(self):
+        return 'Running' if self.started else 'Stopped'
 
     def turn_off(self):
         self.start_time = int(time.time())


### PR DESCRIPTION
Tested with curl

```
ammarhussein@Ammars-MacBook-Air ~ % curl -X POST gardyn:8011/pump/on
{
  "code": 200,
  "pump_status": "Running"
}
ammarhussein@Ammars-MacBook-Air ~ % curl -X POST gardyn:8011/pump/off
{
  "code": 200,
  "pump_status": "Stopped"
}
ammarhussein@Ammars-MacBook-Air ~ % curl gardyn:8011/pump
{
  "code": 200,
  "pump_status": "Stopped"
}
```