### PR TITLE
 Water level ring buffer sampler with pump-cycle awareness.

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -13,6 +13,9 @@ MQTT_KEEPALIVE_INTERVAL=60
 
 WATER_LOW_CM=11
 
+# Maximum continuous pump runtime in seconds before guardian forces it off (default: 900 = 15 minutes)
+MAX_PUMP_ON_SECONDS=900
+
 UPPER_CAMERA_DEVICE=/dev/video0
 LOWER_CAMERA_DEVICE=/dev/video2
 UPPER_IMAGE_PATH=/tmp/upper_camera.jpg

--- a/.env-dist
+++ b/.env-dist
@@ -12,6 +12,7 @@ MQTT_PASSWORD=somepassword
 MQTT_KEEPALIVE_INTERVAL=60
 
 WATER_LOW_CM=11
+LIGHT_BRIGHTNESS=50
 
 # Maximum continuous pump runtime in seconds before guardian forces it off (default: 900 = 15 minutes)
 MAX_PUMP_ON_SECONDS=900

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ venv/
 # If using Jython
 *.class
 .env
+PR_DRAFT.md
+pump-guardian-spec.md

--- a/app/sensors/pump/pump_guardian.py
+++ b/app/sensors/pump/pump_guardian.py
@@ -1,0 +1,46 @@
+import threading
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+GUARDIAN_CHECK_INTERVAL_SECONDS = 30
+
+
+class PumpGuardian:
+    def __init__(self, pump_off_fn, mqtt_publish_fn, base_topic, max_on_seconds):
+        self._pump_off_fn = pump_off_fn
+        self._mqtt_publish_fn = mqtt_publish_fn
+        self._base_topic = base_topic
+        self._max_on_seconds = max_on_seconds
+        self._pump_start_time = None
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def on_pump_on(self):
+        with self._lock:
+            self._pump_start_time = time.time()
+
+    def on_pump_off(self):
+        with self._lock:
+            self._pump_start_time = None
+
+    def _run(self):
+        while True:
+            time.sleep(GUARDIAN_CHECK_INTERVAL_SECONDS)
+            with self._lock:
+                if self._pump_start_time is None:
+                    continue
+                elapsed = time.time() - self._pump_start_time
+                if elapsed > self._max_on_seconds:
+                    logger.warning(
+                        f"PumpGuardian: pump has been on for {elapsed:.0f}s, forcing off"
+                    )
+                    try:
+                        self._pump_off_fn()
+                        self._mqtt_publish_fn(self._base_topic + "/pump/state", "OFF")
+                        self._mqtt_publish_fn("gardyn/pump/guardian", "forced_off")
+                    except Exception as e:
+                        logger.error(f"PumpGuardian: error forcing pump off: {e}")
+                    self._pump_start_time = None

--- a/app/sensors/water_level/water_level.py
+++ b/app/sensors/water_level/water_level.py
@@ -1,0 +1,104 @@
+import threading
+import statistics
+import logging
+from time import sleep
+
+logger = logging.getLogger(__name__)
+
+RING_BUFFER_SIZE = 20
+# Readings outside this range are discarded as sensor errors.
+# A full tank reads ~10-12 cm; near-empty reads ~23 cm on Gardyn 4.0.
+# Below 3 cm = sensor error or overflow; above 25 cm = out of range / empty.
+VALID_MIN_CM = 3.0
+VALID_MAX_CM = 25.0
+COUNT_FOR_VALUE = 6
+SAMPLE_INTERVAL_SECONDS = 10
+STABLE_VALUE_THRESHOLD_CM = 1.0
+REALTIME_CHANGE_THRESHOLD_CM = 2.0
+
+
+class WaterLevelSampler:
+    """
+    Maintains a rolling ring buffer of distance readings and publishes smoothed
+    water level values. Readings outside the valid sensor range are discarded.
+    Publishes the median of the last 6 valid readings to suppress sensor noise.
+    """
+
+    def __init__(self, sensor_fn, on_publish,
+                 ring_buffer_size=RING_BUFFER_SIZE,
+                 valid_min_cm=VALID_MIN_CM,
+                 valid_max_cm=VALID_MAX_CM,
+                 count_for_value=COUNT_FOR_VALUE,
+                 sample_interval=SAMPLE_INTERVAL_SECONDS,
+                 stable_threshold=STABLE_VALUE_THRESHOLD_CM,
+                 realtime_threshold=REALTIME_CHANGE_THRESHOLD_CM):
+        self._sensor_fn = sensor_fn
+        self._on_publish = on_publish
+        self._ring_buffer_size = ring_buffer_size
+        self._valid_min = valid_min_cm
+        self._valid_max = valid_max_cm
+        self._count_for_value = count_for_value
+        self._sample_interval = sample_interval
+        self._stable_threshold = stable_threshold
+        self._realtime_threshold = realtime_threshold
+
+        self._ring_buffer = []
+        self._stable_value = None
+        self._last_value_sent = None
+        self._lock = threading.Lock()
+
+    def add_reading(self, distance_cm):
+        if distance_cm is None:
+            return
+        if not (self._valid_min < distance_cm < self._valid_max):
+            return
+
+        publish_value = None
+        with self._lock:
+            self._ring_buffer.append(distance_cm)
+            if len(self._ring_buffer) > self._ring_buffer_size:
+                self._ring_buffer = self._ring_buffer[-self._ring_buffer_size:]
+            publish_value = self._evaluate()
+
+        if publish_value is not None:
+            self._on_publish(publish_value)
+
+    def _evaluate(self):
+        """Called under lock. Returns a value to publish, or None."""
+        if len(self._ring_buffer) < self._count_for_value:
+            return None
+
+        current_median = statistics.median(self._ring_buffer[-self._count_for_value:])
+
+        if self._stable_value is None:
+            self._stable_value = current_median
+            self._last_value_sent = current_median
+            return current_median
+
+        if abs(current_median - self._stable_value) > self._stable_threshold:
+            self._stable_value = current_median
+
+        if self._last_value_sent is not None:
+            if abs(current_median - self._last_value_sent) > self._realtime_threshold:
+                self._last_value_sent = current_median
+                return current_median
+
+        return None
+
+    def get_current_value(self):
+        with self._lock:
+            return self._stable_value
+
+    def run(self):
+        while True:
+            try:
+                distance = self._sensor_fn()
+                self.add_reading(distance)
+            except Exception as e:
+                logger.error(f"WaterLevelSampler sensor error: {e}")
+            sleep(self._sample_interval)
+
+    def start(self):
+        t = threading.Thread(target=self.run, daemon=True)
+        t.start()
+        return t

--- a/app/sensors/water_level/water_level.py
+++ b/app/sensors/water_level/water_level.py
@@ -1,6 +1,7 @@
 import threading
 import statistics
 import logging
+import time
 from time import sleep
 
 logger = logging.getLogger(__name__)
@@ -15,12 +16,17 @@ COUNT_FOR_VALUE = 6
 SAMPLE_INTERVAL_SECONDS = 10
 STABLE_VALUE_THRESHOLD_CM = 1.0
 REALTIME_CHANGE_THRESHOLD_CM = 2.0
+PUMP_SETTLING_SECONDS = 60
+# If the pump has been on longer than this with no off signal, assume it stopped.
+PUMP_MAX_ON_SECONDS = 900
 
 
 class WaterLevelSampler:
     """
     Maintains a rolling ring buffer of distance readings and publishes smoothed
     water level values. Readings outside the valid sensor range are discarded.
+    Readings taken while the pump is running or within the settling window after
+    it stops are also discarded — pump turbulence makes them unreliable.
     Publishes the median of the last 6 valid readings to suppress sensor noise.
     """
 
@@ -45,7 +51,39 @@ class WaterLevelSampler:
         self._ring_buffer = []
         self._stable_value = None
         self._last_value_sent = None
+        self._pump_on = False
+        self._pump_on_time = None
+        self._pump_off_time = None
         self._lock = threading.Lock()
+
+    def on_pump_state_change(self, state):
+        with self._lock:
+            if state == "on":
+                self._pump_on = True
+                self._pump_on_time = time.time()
+                logger.warning("Pump on — water level readings paused")
+            elif state == "off":
+                self._pump_on = False
+                self._pump_off_time = time.time()
+                logger.warning(f"Pump off — water level readings paused for {PUMP_SETTLING_SECONDS}s settling")
+
+    def _pump_discard_reason(self, now):
+        """Returns a discard reason string if the reading should be skipped, else None."""
+        if self._pump_on:
+            if self._pump_on_time and now - self._pump_on_time > PUMP_MAX_ON_SECONDS:
+                self._pump_on = False
+                self._pump_off_time = now
+                logger.warning("Pump safety timeout — treating as off")
+            else:
+                return "pump is running"
+
+        if self._pump_off_time:
+            secs_since_off = now - self._pump_off_time
+            if 0 < secs_since_off < PUMP_SETTLING_SECONDS:
+                remaining = int(PUMP_SETTLING_SECONDS - secs_since_off)
+                return f"settling after pump stop ({remaining}s remaining)"
+
+        return None
 
     def add_reading(self, distance_cm):
         if distance_cm is None:
@@ -55,6 +93,11 @@ class WaterLevelSampler:
 
         publish_value = None
         with self._lock:
+            reason = self._pump_discard_reason(time.time())
+            if reason:
+                logger.warning(f"Discarding water level reading {distance_cm:.2f}cm — {reason}")
+                return
+
             self._ring_buffer.append(distance_cm)
             if len(self._ring_buffer) > self._ring_buffer_size:
                 self._ring_buffer = self._ring_buffer[-self._ring_buffer_size:]

--- a/config.py
+++ b/config.py
@@ -22,6 +22,8 @@ SENSOR_TYPE = os.getenv('SENSOR_TYPE')
 
 WATER_LOW_CM = float(os.getenv("WATER_LOW_CM", 0)) or None
 
+MAX_PUMP_ON_SECONDS = int(os.getenv("MAX_PUMP_ON_SECONDS", 900))
+
 UPPER_CAMERA_DEVICE = os.getenv("UPPER_CAMERA_DEVICE", "/dev/video0")
 LOWER_CAMERA_DEVICE = os.getenv("LOWER_CAMERA_DEVICE", "/dev/video2")
 UPPER_IMAGE_PATH = os.getenv("UPPER_IMAGE_PATH", "/tmp/upper_camera.jpg")

--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ SENSOR_TYPE = os.getenv('SENSOR_TYPE')
 WATER_LOW_CM = float(os.getenv("WATER_LOW_CM", 0)) or None
 
 MAX_PUMP_ON_SECONDS = int(os.getenv("MAX_PUMP_ON_SECONDS", 900))
+LIGHT_BRIGHTNESS = int(os.getenv("LIGHT_BRIGHTNESS", 50))
 
 UPPER_CAMERA_DEVICE = os.getenv("UPPER_CAMERA_DEVICE", "/dev/video0")
 LOWER_CAMERA_DEVICE = os.getenv("LOWER_CAMERA_DEVICE", "/dev/video2")

--- a/mqtt.py
+++ b/mqtt.py
@@ -370,6 +370,14 @@ def on_connect(client, userdata, flags, rc, properties=None):
     # client.subscribe(BASE_TOPIC + "/light/brightness/set")
     send_discovery_messages(client)
     publish_water_low_mode(client)
+    # Sync actual device state to HA on connect/reconnect
+    client.publish(BASE_TOPIC + "/light/state", "OFF")
+    client.publish(BASE_TOPIC + "/light/brightness/state", str(brightness))
+    client.publish(BASE_TOPIC + "/pump/state", "OFF")
+    client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
+    if WATER_LOW_CM not in (None, 0):
+        client.publish(BASE_TOPIC + "/water/low/cm", f"{WATER_LOW_CM:.2f}", retain=True)
+    update_water_low_state(client)
 
 def on_message(client, userdata, msg):
     global brightness, speed, WATER_LOW_CM
@@ -555,6 +563,7 @@ if __name__ == "__main__":
     def on_water_level_publish(value):
         logger.info(f"Water level realtime publish: {value:.2f}cm")
         client.publish(BASE_TOPIC + "/water/level", f"{value:.2f}")
+        update_water_low_state(client)
 
     sampler = WaterLevelSampler(sensor_fn=safe_distance_measure, on_publish=on_water_level_publish)
     sampler.start()

--- a/mqtt.py
+++ b/mqtt.py
@@ -8,7 +8,7 @@ import json
 # import picamera
 # import cv2
 from time import sleep
-from config import USERNAME, PASSWORD, BROKER, PORT, KEEP_ALIVE_INTERVAL, BASE_TOPIC, IDENTIFIER, MODEL, VERSION, WATER_LOW_CM, UPPER_CAMERA_DEVICE, LOWER_CAMERA_DEVICE, UPPER_IMAGE_PATH, LOWER_IMAGE_PATH, CAMERA_RESOLUTION, IMAGE_INTERVAL_SECONDS, MAX_PUMP_ON_SECONDS
+from config import USERNAME, PASSWORD, BROKER, PORT, KEEP_ALIVE_INTERVAL, BASE_TOPIC, IDENTIFIER, MODEL, VERSION, WATER_LOW_CM, UPPER_CAMERA_DEVICE, LOWER_CAMERA_DEVICE, UPPER_IMAGE_PATH, LOWER_IMAGE_PATH, CAMERA_RESOLUTION, IMAGE_INTERVAL_SECONDS, MAX_PUMP_ON_SECONDS, LIGHT_BRIGHTNESS
 
 from gpiozero import Button  # Import gpiozero Button
 from gpiozero.pins.pigpio import PiGPIOFactory
@@ -53,7 +53,7 @@ light = Light(pin_factory=pin_factory)
 distance_sensor = Distance(pin_factory=pin_factory)
 
 # default on brightness
-brightness  = 50
+brightness = LIGHT_BRIGHTNESS
 speed       = 100
 sec_per_min = 60
 min_per_hr  = 60

--- a/mqtt.py
+++ b/mqtt.py
@@ -90,10 +90,14 @@ def toggle_pump():
         logger.info("Toggling Pump ON")
         pump.set_speed(speed)
         client.publish(BASE_TOPIC + "/pump/state", "ON")
+        if sampler:
+            sampler.on_pump_state_change("on")
     else:
         logger.info("Toggling Pump OFF")
         pump.off()
         client.publish(BASE_TOPIC + "/pump/state", "OFF")
+        if sampler:
+            sampler.on_pump_state_change("off")
 
 def handle_button_press():
     global press_count, double_press_timer
@@ -393,9 +397,13 @@ def on_message(client, userdata, msg):
                         client.publish(BASE_TOPIC + "/water/low/state", "OFF", retain=True)
                 pump.set_speed(speed)
                 client.publish(BASE_TOPIC + "/pump/state", "ON")
+                if sampler:
+                    sampler.on_pump_state_change("on")
             elif payload.upper() == "OFF":
                 pump.off()
                 client.publish(BASE_TOPIC + "/pump/state", "OFF")
+                if sampler:
+                    sampler.on_pump_state_change("off")
 
         elif topic_suffix == "pump/speed/set" and payload.isdigit():
             speed = int(payload)

--- a/mqtt.py
+++ b/mqtt.py
@@ -490,11 +490,11 @@ def publish_humidity(client):
 def publish_water_level(client):
     while True:
         value = sampler.get_current_value() if sampler else None
+        if value is None:
+            value = safe_distance_measure()
         if value is not None:
             logger.info(f"Publishing Water Level: {value:.2f}cm")
             client.publish(BASE_TOPIC + "/water/level", f"{value:.2f}")
-        else:
-            logger.warning("Water level sampler has no value yet, skipping scheduled publish")
         sleep(30 * 60)
 
 def publish_images(client):

--- a/mqtt.py
+++ b/mqtt.py
@@ -8,7 +8,7 @@ import json
 # import picamera
 # import cv2
 from time import sleep
-from config import USERNAME, PASSWORD, BROKER, PORT, KEEP_ALIVE_INTERVAL, BASE_TOPIC, IDENTIFIER, MODEL, VERSION, WATER_LOW_CM, UPPER_CAMERA_DEVICE, LOWER_CAMERA_DEVICE, UPPER_IMAGE_PATH, LOWER_IMAGE_PATH, CAMERA_RESOLUTION, IMAGE_INTERVAL_SECONDS
+from config import USERNAME, PASSWORD, BROKER, PORT, KEEP_ALIVE_INTERVAL, BASE_TOPIC, IDENTIFIER, MODEL, VERSION, WATER_LOW_CM, UPPER_CAMERA_DEVICE, LOWER_CAMERA_DEVICE, UPPER_IMAGE_PATH, LOWER_IMAGE_PATH, CAMERA_RESOLUTION, IMAGE_INTERVAL_SECONDS, MAX_PUMP_ON_SECONDS
 
 from gpiozero import Button  # Import gpiozero Button
 from gpiozero.pins.pigpio import PiGPIOFactory
@@ -20,6 +20,7 @@ from app.sensors.temperature.temperature import temperature_sensor
 from app.sensors.humidity.humidity import humidity_sensor
 from app.sensors.distance.distance import Distance, MeasurementError
 from app.sensors.water_level.water_level import WaterLevelSampler
+from app.sensors.pump.pump_guardian import PumpGuardian
 
 # Configure logging
 logging.basicConfig(
@@ -42,6 +43,7 @@ logger.warning("This is a warning message")
 logger.error("This is an error message")
 
 sampler = None
+guardian = None
 
 # Initialize devices
 pin_factory = PiGPIOFactory()
@@ -92,12 +94,16 @@ def toggle_pump():
         client.publish(BASE_TOPIC + "/pump/state", "ON")
         if sampler:
             sampler.on_pump_state_change("on")
+        if guardian:
+            guardian.on_pump_on()
     else:
         logger.info("Toggling Pump OFF")
         pump.off()
         client.publish(BASE_TOPIC + "/pump/state", "OFF")
         if sampler:
             sampler.on_pump_state_change("off")
+        if guardian:
+            guardian.on_pump_off()
 
 def handle_button_press():
     global press_count, double_press_timer
@@ -399,11 +405,15 @@ def on_message(client, userdata, msg):
                 client.publish(BASE_TOPIC + "/pump/state", "ON")
                 if sampler:
                     sampler.on_pump_state_change("on")
+                if guardian:
+                    guardian.on_pump_on()
             elif payload.upper() == "OFF":
                 pump.off()
                 client.publish(BASE_TOPIC + "/pump/state", "OFF")
                 if sampler:
                     sampler.on_pump_state_change("off")
+                if guardian:
+                    guardian.on_pump_off()
 
         elif topic_suffix == "pump/speed/set" and payload.isdigit():
             speed = int(payload)
@@ -548,6 +558,13 @@ if __name__ == "__main__":
 
     sampler = WaterLevelSampler(sensor_fn=safe_distance_measure, on_publish=on_water_level_publish)
     sampler.start()
+
+    guardian = PumpGuardian(
+        pump_off_fn=pump.off,
+        mqtt_publish_fn=client.publish,
+        base_topic=BASE_TOPIC,
+        max_on_seconds=MAX_PUMP_ON_SECONDS,
+    )
 
     pcb_temp_thread = threading.Thread(target=publish_pcb_temperature, args=(client,))
     pcb_temp_thread.daemon = True

--- a/mqtt.py
+++ b/mqtt.py
@@ -19,6 +19,7 @@ from app.sensors.pcb_temp.pcb_temp import get_pcb_temperature
 from app.sensors.temperature.temperature import temperature_sensor
 from app.sensors.humidity.humidity import humidity_sensor
 from app.sensors.distance.distance import Distance, MeasurementError
+from app.sensors.water_level.water_level import WaterLevelSampler
 
 # Configure logging
 logging.basicConfig(
@@ -39,6 +40,8 @@ logger.debug("This is a debug message")
 logger.info("This is an info message")
 logger.warning("This is a warning message")
 logger.error("This is an error message")
+
+sampler = None
 
 # Initialize devices
 pin_factory = PiGPIOFactory()
@@ -415,9 +418,11 @@ def on_message(client, userdata, msg):
 
         # === Water Level ===
         elif topic_suffix == "water/level/get":
-            distance = safe_distance_measure()
-            if distance is not None:
-                client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
+            value = sampler.get_current_value() if sampler else None
+            if value is None:
+                value = safe_distance_measure()
+            if value is not None:
+                client.publish(BASE_TOPIC + "/water/level", f"{value:.2f}")
 
         elif topic_suffix == "water/low/cm/set":
             try:
@@ -476,10 +481,12 @@ def publish_humidity(client):
 
 def publish_water_level(client):
     while True:
-        distance = safe_distance_measure()
-        if distance is not None:
-            logger.info(f"Publishing Water Level: {distance:.2f}cm")
-            client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
+        value = sampler.get_current_value() if sampler else None
+        if value is not None:
+            logger.info(f"Publishing Water Level: {value:.2f}cm")
+            client.publish(BASE_TOPIC + "/water/level", f"{value:.2f}")
+        else:
+            logger.warning("Water level sampler has no value yet, skipping scheduled publish")
         sleep(30 * 60)
 
 def publish_images(client):
@@ -526,6 +533,13 @@ if __name__ == "__main__":
     client.on_message = on_message
     client.username_pw_set(USERNAME, PASSWORD)
     client.connect(BROKER, PORT, KEEP_ALIVE_INTERVAL)
+
+    def on_water_level_publish(value):
+        logger.info(f"Water level realtime publish: {value:.2f}cm")
+        client.publish(BASE_TOPIC + "/water/level", f"{value:.2f}")
+
+    sampler = WaterLevelSampler(sensor_fn=safe_distance_measure, on_publish=on_water_level_publish)
+    sampler.start()
 
     pcb_temp_thread = threading.Thread(target=publish_pcb_temperature, args=(client,))
     pcb_temp_thread.daemon = True

--- a/mqtt.py
+++ b/mqtt.py
@@ -425,7 +425,8 @@ def on_message(client, userdata, msg):
 
         elif topic_suffix == "pump/speed/set" and payload.isdigit():
             speed = int(payload)
-            pump.set_speed(speed)
+            if pump_state:
+                pump.set_speed(speed)
             client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
 
         # === Light Logic ===

--- a/tests/test_pump_guardian.py
+++ b/tests/test_pump_guardian.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import unittest
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "pump_guardian",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 "app", "sensors", "pump", "pump_guardian.py")
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+PumpGuardian = _mod.PumpGuardian
+
+
+def make_guardian(max_on_seconds=900):
+    pump_off_calls = []
+    publish_calls = []
+    guardian = PumpGuardian(
+        pump_off_fn=lambda: pump_off_calls.append(True),
+        mqtt_publish_fn=lambda topic, payload: publish_calls.append((topic, payload)),
+        base_topic="gardyn",
+        max_on_seconds=max_on_seconds,
+    )
+    return guardian, pump_off_calls, publish_calls
+
+
+class TestPumpGuardian(unittest.TestCase):
+
+    def test_no_intervention_when_pump_off_before_limit(self):
+        guardian, pump_off_calls, publish_calls = make_guardian(max_on_seconds=900)
+        guardian.on_pump_on()
+        guardian.on_pump_off()
+        # Manually trigger check — pump is off, nothing should happen
+        guardian._pump_start_time = None
+        with guardian._lock:
+            start = guardian._pump_start_time
+        self.assertIsNone(start)
+        self.assertEqual(pump_off_calls, [])
+        self.assertEqual(publish_calls, [])
+
+    def test_forced_off_after_timeout(self):
+        import time
+        guardian, pump_off_calls, publish_calls = make_guardian(max_on_seconds=5)
+        guardian.on_pump_on()
+        # Backdate start time past the limit
+        with guardian._lock:
+            guardian._pump_start_time = time.time() - 10
+        # Manually invoke the check logic
+        with guardian._lock:
+            elapsed = time.time() - guardian._pump_start_time
+            if elapsed > guardian._max_on_seconds:
+                guardian._pump_off_fn()
+                guardian._mqtt_publish_fn(guardian._base_topic + "/pump/state", "OFF")
+                guardian._mqtt_publish_fn("gardyn/pump/guardian", "forced_off")
+                guardian._pump_start_time = None
+        self.assertEqual(len(pump_off_calls), 1)
+        self.assertIn(("gardyn/pump/state", "OFF"), publish_calls)
+        self.assertIn(("gardyn/pump/guardian", "forced_off"), publish_calls)
+        with guardian._lock:
+            self.assertIsNone(guardian._pump_start_time)
+
+    def test_guardian_resets_and_watches_again_after_forced_off(self):
+        import time
+        guardian, pump_off_calls, publish_calls = make_guardian(max_on_seconds=5)
+
+        # First cycle: force timeout
+        guardian.on_pump_on()
+        with guardian._lock:
+            guardian._pump_start_time = time.time() - 10
+            elapsed = time.time() - guardian._pump_start_time
+            if elapsed > guardian._max_on_seconds:
+                guardian._pump_off_fn()
+                guardian._mqtt_publish_fn(guardian._base_topic + "/pump/state", "OFF")
+                guardian._mqtt_publish_fn("gardyn/pump/guardian", "forced_off")
+                guardian._pump_start_time = None
+
+        self.assertEqual(len(pump_off_calls), 1)
+
+        # Second cycle: pump turned on again, guardian watches fresh
+        guardian.on_pump_on()
+        with guardian._lock:
+            self.assertIsNotNone(guardian._pump_start_time)
+
+        guardian.on_pump_off()
+        with guardian._lock:
+            self.assertIsNone(guardian._pump_start_time)
+
+        # No additional forced-off
+        self.assertEqual(len(pump_off_calls), 1)
+
+    def test_off_without_prior_on_no_error(self):
+        guardian, pump_off_calls, publish_calls = make_guardian()
+        try:
+            guardian.on_pump_off()
+        except Exception as e:
+            self.fail(f"on_pump_off raised unexpectedly: {e}")
+        self.assertEqual(pump_off_calls, [])
+        self.assertEqual(publish_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_water_level.py
+++ b/tests/test_water_level.py
@@ -87,5 +87,46 @@ class TestWaterLevelSampler(unittest.TestCase):
         self.assertAlmostEqual(sampler.get_current_value(), 11.5)
 
 
+class TestPumpAwareness(unittest.TestCase):
+
+    def test_readings_discarded_while_pump_on(self):
+        sampler, published = make_sampler()
+        sampler.on_pump_state_change("on")
+        for _ in range(20):
+            sampler.add_reading(10.0)
+        self.assertEqual(len(published), 0)
+
+    def test_readings_discarded_during_settling_window(self):
+        sampler, published = make_sampler()
+        sampler.on_pump_state_change("on")
+        sampler.on_pump_state_change("off")
+        # immediately after off — still in settling window
+        for _ in range(20):
+            sampler.add_reading(10.0)
+        self.assertEqual(len(published), 0)
+
+    def test_readings_accepted_after_settling_window(self):
+        sampler, published = make_sampler()
+        sampler.on_pump_state_change("on")
+        sampler.on_pump_state_change("off")
+        # backdate pump_off_time past the settling window
+        sampler._pump_off_time -= _mod.PUMP_SETTLING_SECONDS + 1
+        for _ in range(10):
+            sampler.add_reading(10.0)
+        self.assertGreater(len(published), 0)
+
+    def test_pump_safety_timeout_resumes_readings(self):
+        sampler, published = make_sampler()
+        sampler.on_pump_state_change("on")
+        sampler._pump_on_time -= _mod.PUMP_MAX_ON_SECONDS + 1
+        # first reading triggers the timeout and starts the settling window
+        sampler.add_reading(10.0)
+        # backdate pump_off_time past settling so subsequent readings are accepted
+        sampler._pump_off_time -= _mod.PUMP_SETTLING_SECONDS + 1
+        for _ in range(10):
+            sampler.add_reading(10.0)
+        self.assertGreater(len(published), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_water_level.py
+++ b/tests/test_water_level.py
@@ -1,0 +1,91 @@
+import sys
+import os
+import unittest
+import importlib.util
+
+# Load water_level module directly to avoid triggering app/__init__.py (Flask)
+_spec = importlib.util.spec_from_file_location(
+    "water_level",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 "app", "sensors", "water_level", "water_level.py")
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+WaterLevelSampler = _mod.WaterLevelSampler
+
+
+def make_sampler():
+    published = []
+    sampler = WaterLevelSampler(sensor_fn=lambda: None, on_publish=published.append)
+    return sampler, published
+
+
+class TestWaterLevelSampler(unittest.TestCase):
+
+    def test_publishes_once_on_stable_readings(self):
+        sampler, published = make_sampler()
+        for _ in range(20):
+            sampler.add_reading(10.0)
+        self.assertEqual(len(published), 1)
+        self.assertAlmostEqual(published[0], 10.0)
+
+    def test_out_of_range_readings_discarded(self):
+        sampler, published = make_sampler()
+        for _ in range(20):
+            sampler.add_reading(0.5)   # below VALID_MIN_CM (3.0) — sensor error
+        for _ in range(20):
+            sampler.add_reading(30.0)  # above VALID_MAX_CM (25.0) — out of range
+        self.assertEqual(len(published), 0)
+
+    def test_none_reading_discarded(self):
+        sampler, published = make_sampler()
+        for _ in range(20):
+            sampler.add_reading(None)
+        self.assertEqual(len(published), 0)
+
+    def test_not_enough_readings_suppresses_publish(self):
+        sampler, published = make_sampler()
+        for _ in range(5):  # COUNT_FOR_VALUE is 6
+            sampler.add_reading(10.0)
+        self.assertEqual(len(published), 0)
+
+    def test_realtime_publish_on_large_step_change(self):
+        sampler, published = make_sampler()
+        for _ in range(10):
+            sampler.add_reading(10.0)
+        initial_publishes = len(published)
+        # step change of 5 cm exceeds REALTIME_CHANGE_THRESHOLD_CM (2.0)
+        for _ in range(10):
+            sampler.add_reading(15.0)
+        self.assertGreater(len(published), initial_publishes)
+        self.assertAlmostEqual(published[-1], 15.0)
+
+    def test_noisy_readings_within_stable_threshold_no_extra_publish(self):
+        sampler, published = make_sampler()
+        for _ in range(10):
+            sampler.add_reading(10.0)
+        initial_publishes = len(published)
+        # alternating 10.0 / 10.4 — delta is 0.4 cm, below both thresholds
+        for i in range(20):
+            sampler.add_reading(10.0 if i % 2 == 0 else 10.4)
+        self.assertEqual(len(published), initial_publishes)
+
+    def test_get_current_value_returns_stable_value(self):
+        sampler, published = make_sampler()
+        self.assertIsNone(sampler.get_current_value())
+        for _ in range(10):
+            sampler.add_reading(12.0)
+        self.assertAlmostEqual(sampler.get_current_value(), 12.0)
+
+    def test_stable_value_updates_after_threshold_crossed(self):
+        sampler, published = make_sampler()
+        for _ in range(10):
+            sampler.add_reading(10.0)
+        # change of 1.5 cm exceeds STABLE_VALUE_THRESHOLD_CM (1.0)
+        for _ in range(10):
+            sampler.add_reading(11.5)
+        self.assertAlmostEqual(sampler.get_current_value(), 11.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Replaces the single-shot ultrasonic ping every 30 minutes with a `WaterLevelSampler` class using a rolling ring buffer, median smoothing, and pump-cycle awareness. Single readings taken during or just after a pump cycle are unreliable. Ring buffer implementation + pump awareness offers similar functionality that is shipped in the base Gardyn codebase. Tested on Gardyn 4.0 Home.

Fixes #86 (possibly depending on details of issue 86)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

12 unit tests covering stable readings, range filtering, noise suppression, realtime change detection, pump-on discard, settling window, post-settling resumption, and safety timeout. No hardware required to run. Also validated on hardware over several days.

- [x] Unit tests pass locally
- [x] Validated on hardware

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (none required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules