### PR TITLE
Harden runtime initialization and tests

### DIFF
--- a/app/lib/lib.py
+++ b/app/lib/lib.py
@@ -1,12 +1,17 @@
 from flask import jsonify
 from functools import wraps
 
+def sensor_provider(func):
+    func._is_sensor_provider = True
+    return func
+
 def check_sensor_guard(sensor, sensor_name):
     def decorator(func):
         # helps to maintain the wrapped functions metadata, otherwise Flask will complain about duplicate routes
         @wraps(func)
         def check_sensor(*args, **kwargs):
-            if sensor == None:
+            current_sensor = sensor() if getattr(sensor, '_is_sensor_provider', False) else sensor
+            if current_sensor == None:
                 return jsonify(error=f'{sensor_name} are not initialized'), 400
             return func(*args, **kwargs)
         return check_sensor

--- a/app/sensors/distance/distance.py
+++ b/app/sensors/distance/distance.py
@@ -30,6 +30,7 @@ class Distance:
         Raises:
             MeasurementError: If the DistanceSensor fails to initialize.
         """
+        self.owns_pin_factory = pin_factory is None
         self.pin_factory = pin_factory if pin_factory else PiGPIOFactory()
         try:
             self.sensor = DistanceSensor(echo=19, trigger=26, pin_factory=self.pin_factory)
@@ -96,6 +97,31 @@ class Distance:
         else:
             mid = data_length // 2
             return [(sorted_data[mid - 1] + sorted_data[mid]) / 2]
+
+    def cleanup(self):
+        """
+        Properly closes the sensor and pin factory connections.
+        """
+        try:
+            if hasattr(self, 'sensor') and self.sensor:
+                self.sensor.close()
+            if self.owns_pin_factory and hasattr(self, 'pin_factory') and self.pin_factory:
+                self.pin_factory.close()
+        except Exception as e:
+            print(f"Warning during cleanup: {e}")
+
+    def __enter__(self):
+        """
+        Context manager entry.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Context manager exit, ensuring resources are closed.
+        """
+        self.cleanup()
+        return False
 
 if __name__ == "__main__":
     """

--- a/app/sensors/distance/routes.py
+++ b/app/sensors/distance/routes.py
@@ -1,14 +1,24 @@
 from flask import Blueprint, request, jsonify
-from app.lib.lib import check_sensor_guard
+from app.lib.lib import check_sensor_guard, sensor_provider
 from .distance import Distance as DistanceControl 
 
 distance_blueprint = Blueprint('distance', __name__)
-distance_control = DistanceControl()
-check_sensor = check_sensor_guard(sensor=distance_control, sensor_name="Distance")
+distance_control = None
+
+@sensor_provider
+def get_distance_control():
+    global distance_control
+    if distance_control is None:
+        try:
+            distance_control = DistanceControl()
+        except Exception:
+            return None
+    return distance_control
+
+check_sensor = check_sensor_guard(sensor=get_distance_control, sensor_name="Distance")
 
 @distance_blueprint.route('', methods=['GET'])
 @check_sensor
 def get_distance():
-    distance_value = distance_control.measure_once()
+    distance_value = get_distance_control().measure_once()
     return jsonify(distance=distance_value), 200
-

--- a/app/sensors/humidity/humidity.py
+++ b/app/sensors/humidity/humidity.py
@@ -3,11 +3,6 @@ This module provides functionality to read humidity values from the AM2320 senso
 using the adafruit_ahtx0 library.
 """
 
-import time
-import board
-import adafruit_ahtx0
-import adafruit_am2320
-
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -30,24 +25,33 @@ class HumiditySensor:
 
 humidity_sensor = None 
 
-try:
-    i2c = board.I2C()
-    if config.SENSOR_TYPE == 'AM2320':
-        base_sensor = adafruit_am2320.AM2320(i2c, address=0x5C)
-    elif config.SENSOR_TYPE == 'DHT20':
-        base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
-    else:
-        raise ValueError("Unsupported sensor type")
-    humidity_sensor = HumiditySensor(base_sensor)
-except:
-    print("Failed to initiate humidity sensor")
+def get_humidity_sensor():
+    global humidity_sensor
+    if humidity_sensor is not None:
+        return humidity_sensor
+    try:
+        import board
+        import adafruit_ahtx0
+        import adafruit_am2320
+
+        i2c = board.I2C()
+        if config.SENSOR_TYPE == 'AM2320':
+            base_sensor = adafruit_am2320.AM2320(i2c, address=0x5C)
+        elif config.SENSOR_TYPE == 'DHT20':
+            base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
+        else:
+            raise ValueError("Unsupported sensor type")
+        humidity_sensor = HumiditySensor(base_sensor)
+    except Exception:
+        print("Failed to initiate humidity sensor")
+    return humidity_sensor
 
 if __name__ == "__main__":
     """
     If the module is executed as a standalone script, it will return the humidity in a telegraf friendly format. 
     """
     try:
-        humidity = humidity_sensor.read()
+        humidity = get_humidity_sensor().read()
         print(f"humidity, value={humidity:.2f}")
     except Exception as e:
         print(f"Error: {e}")

--- a/app/sensors/humidity/routes.py
+++ b/app/sensors/humidity/routes.py
@@ -1,11 +1,16 @@
 from flask import Blueprint, jsonify
-from app.lib.lib import check_sensor_guard
-from .humidity import humidity_sensor
+from app.lib.lib import check_sensor_guard, sensor_provider
+from .humidity import get_humidity_sensor as load_humidity_sensor
 
 humidity_blueprint = Blueprint('humidity', __name__)
-check_sensor = check_sensor_guard(sensor=humidity_sensor, sensor_name='Humidity')
+
+@sensor_provider
+def get_humidity_sensor():
+    return load_humidity_sensor()
+
+check_sensor = check_sensor_guard(sensor=get_humidity_sensor, sensor_name='Humidity')
 
 @humidity_blueprint.route('', methods=['GET'])
 @check_sensor
 def get_humidity():
-    return jsonify(humidity='{:.2f}'.format(humidity_sensor.read()))
+    return jsonify(humidity='{:.2f}'.format(get_humidity_sensor().read()))

--- a/app/sensors/light/routes.py
+++ b/app/sensors/light/routes.py
@@ -1,21 +1,32 @@
-from app.lib.lib import check_sensor_guard
+from app.lib.lib import check_sensor_guard, sensor_provider
 from flask import Blueprint, request, jsonify
 from .light import Light as LightControl  # Assuming you have a model for Light
 
 light_blueprint = Blueprint('light', __name__)
-light_control = LightControl()
-check_sensor = check_sensor_guard(sensor=light_control, sensor_name='Light')
+light_control = None
+
+@sensor_provider
+def get_light_control():
+    global light_control
+    if light_control is None:
+        try:
+            light_control = LightControl()
+        except Exception:
+            return None
+    return light_control
+
+check_sensor = check_sensor_guard(sensor=get_light_control, sensor_name='Light')
 
 @light_blueprint.route('/on', methods=['POST'])
 @check_sensor
 def turn_on():
-    light_control.on()
+    get_light_control().on()
     return jsonify(message="Light turned on"), 200
 
 @light_blueprint.route('/off', methods=['POST'])
 @check_sensor
 def turn_off():
-    light_control.off()
+    get_light_control().off()
     return jsonify(message="Light turned off"), 200
 
 @light_blueprint.route('/brightness', methods=['POST'])
@@ -24,7 +35,7 @@ def set_brightness():
     data = request.get_json()
     brightness_value = data.get('value', 50) 
     try:
-        light_control.set_brightness(brightness_value)
+        get_light_control().set_brightness(brightness_value)
         return jsonify(message=f"Light adjusted to {brightness_value}%"), 200
     except ValueError as e:
         return jsonify(message=str(e)), 400
@@ -32,5 +43,5 @@ def set_brightness():
 @light_blueprint.route('/brightness', methods=['GET'])
 @check_sensor
 def get_brightness():
-    brightness_value = light_control.get_brightness()
+    brightness_value = get_light_control().get_brightness()
     return jsonify(value=brightness_value), 200

--- a/app/sensors/pcb_temp/pcb_temp.py
+++ b/app/sensors/pcb_temp/pcb_temp.py
@@ -1,7 +1,7 @@
-import board
-import adafruit_pct2075
-
 def get_pcb_temperature():
+    import board
+    import adafruit_pct2075
+
     i2c = board.I2C()  # uses board.SCL and board.SDA
     pct = adafruit_pct2075.PCT2075(i2c, address=0x48)
     

--- a/app/sensors/pcb_temp/routes.py
+++ b/app/sensors/pcb_temp/routes.py
@@ -8,4 +8,7 @@ check_sensor = check_sensor_guard(sensor=get_pcb_temperature, sensor_name='PCB T
 @pcb_temp_blueprint.route('', methods=['GET'])
 @check_sensor
 def get_pcb_temp():
-    return jsonify({"pcb-temp": '{:.2f}'.format(get_pcb_temperature())})
+    try:
+        return jsonify({"pcb-temp": '{:.2f}'.format(get_pcb_temperature())})
+    except Exception:
+        return jsonify(error='PCB Temp are not initialized'), 400

--- a/app/sensors/pump/pump.py
+++ b/app/sensors/pump/pump.py
@@ -21,6 +21,10 @@ class GPIOController:
             self.pi.set_PWM_frequency(self.pin, frequency)
         else:
             raise RuntimeError("pigpio.pi client is not initialized.")
+
+    def stop(self):
+        if self.pi:
+            self.pi.stop()
         
 class Pump:
     def __init__(self, pin=24, frequency=50, pin_factory=None):

--- a/app/sensors/pump/pump_power.py
+++ b/app/sensors/pump/pump_power.py
@@ -1,12 +1,11 @@
 # coding=utf-8
-import smbus
-from ina219 import INA219
-from ina219 import DeviceRangeError
 import time
 
 SHUNT_OHMS = 0.08
 
 def is_ina219_present(address):
+    import smbus
+
     try:
         bus = smbus.SMBus(1)  # Use SMBus(0) for older versions of Raspberry Pi
         bus.read_byte_data(address, 0)  # Try to read a byte from the specified address
@@ -15,6 +14,9 @@ def is_ina219_present(address):
         return False
 
 def fetch_ina219_data():
+    from ina219 import INA219
+    from ina219 import DeviceRangeError
+
     data = {}
     if is_ina219_present(0x40):  # Check if the INA219 is present at address 0x40
         try:

--- a/app/sensors/pump/routes.py
+++ b/app/sensors/pump/routes.py
@@ -1,22 +1,33 @@
 from flask import Blueprint, request, jsonify
-from app.lib.lib import check_sensor_guard
+from app.lib.lib import check_sensor_guard, sensor_provider
 from .pump import Pump as PumpControl 
 from .pump_power import fetch_ina219_data
 
 pump_blueprint = Blueprint('pump', __name__)
-pump_control = PumpControl()
-check_sensor = check_sensor_guard(sensor=pump_control, sensor_name='Pump')
+pump_control = None
+
+@sensor_provider
+def get_pump_control():
+    global pump_control
+    if pump_control is None:
+        try:
+            pump_control = PumpControl()
+        except Exception:
+            return None
+    return pump_control
+
+check_sensor = check_sensor_guard(sensor=get_pump_control, sensor_name='Pump')
 
 @pump_blueprint.route('/on', methods=['POST'])
 @check_sensor
 def turn_on():
-    pump_control.on()
+    get_pump_control().on()
     return jsonify(message="Pump turned on!"), 200
 
 @pump_blueprint.route('/off', methods=['POST'])
 @check_sensor
 def turn_off():
-    pump_control.off()
+    get_pump_control().off()
     return jsonify(message="Pump turned off!"), 200
 
 @pump_blueprint.route('/speed', methods=['POST'])
@@ -25,7 +36,7 @@ def adjust_speed():
     data = request.get_json()
     speed_value = data.get('value', 30)  # default to 30 percent
     try:
-        pump_control.set_speed(speed_value)
+        get_pump_control().set_speed(speed_value)
         return jsonify(message=f"Pump adjusted to {speed_value}% speed!"), 200
     except ValueError as e:
         return jsonify(message=str(e)), 400
@@ -33,7 +44,7 @@ def adjust_speed():
 @pump_blueprint.route('/speed', methods=['GET'])
 @check_sensor
 def get_speed():
-    current_speed = pump_control.get_speed()
+    current_speed = get_pump_control().get_speed()
     return jsonify(value=current_speed), 200
 
 @pump_blueprint.route('/stats', methods=['GET'])

--- a/app/sensors/temperature/routes.py
+++ b/app/sensors/temperature/routes.py
@@ -1,11 +1,16 @@
 from flask import Blueprint, jsonify
-from app.lib.lib import check_sensor_guard
-from .temperature import temperature_sensor
+from app.lib.lib import check_sensor_guard, sensor_provider
+from .temperature import get_temperature_sensor as load_temperature_sensor
 
 temperature_blueprint = Blueprint('temperature', __name__)
-check_sensor = check_sensor_guard(sensor=temperature_sensor, sensor_name='Temperature')
+
+@sensor_provider
+def get_temperature_sensor():
+    return load_temperature_sensor()
+
+check_sensor = check_sensor_guard(sensor=get_temperature_sensor, sensor_name='Temperature')
 
 @temperature_blueprint.route('', methods=['GET'])
 @check_sensor
 def get_temperature():    
-    return jsonify(temperature='{:.2f}'.format(temperature_sensor.read()))
+    return jsonify(temperature='{:.2f}'.format(get_temperature_sensor().read()))

--- a/app/sensors/temperature/temperature.py
+++ b/app/sensors/temperature/temperature.py
@@ -3,11 +3,6 @@ This module provides functionality to read temperature values from the AM2320 se
 using the adafruit_ahtx0 library.
 """
 
-import time
-import board
-import adafruit_ahtx0
-import adafruit_am2320
-
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -30,24 +25,33 @@ class TemperatureSensor:
 
 temperature_sensor = None 
 
-try:
-    i2c = board.I2C()
-    if config.SENSOR_TYPE == 'AM2320':
-        base_sensor = adafruit_am2320.AM2320(i2c)
-    elif config.SENSOR_TYPE == 'DHT20':
-        base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
-    else:
-        raise ValueError("Unsupported sensor type")
-    temperature_sensor = TemperatureSensor(base_sensor)
-except:
-    print("Failed to initiate temperature sensor")
+def get_temperature_sensor():
+    global temperature_sensor
+    if temperature_sensor is not None:
+        return temperature_sensor
+    try:
+        import board
+        import adafruit_ahtx0
+        import adafruit_am2320
+
+        i2c = board.I2C()
+        if config.SENSOR_TYPE == 'AM2320':
+            base_sensor = adafruit_am2320.AM2320(i2c)
+        elif config.SENSOR_TYPE == 'DHT20':
+            base_sensor = adafruit_ahtx0.AHTx0(i2c, address=0x38)
+        else:
+            raise ValueError("Unsupported sensor type")
+        temperature_sensor = TemperatureSensor(base_sensor)
+    except Exception:
+        print("Failed to initiate temperature sensor")
+    return temperature_sensor
 
 if __name__ == "__main__":
     """
     If the module is executed as a standalone script, it will return the temperature in a telegraf friendly format. 
     """
     try:
-        temperature = temperature_sensor.read()
+        temperature = get_temperature_sensor().read()
         print(f"temperature, value={temperature:.2f}")
     except Exception as e:
         print(f"Error: {e}")

--- a/config.py
+++ b/config.py
@@ -4,10 +4,32 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
+def _get_int(name, default, minimum=None, maximum=None):
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
+
+def _get_float(name, default, minimum=None, maximum=None):
+    try:
+        value = float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
+
 # MQTT configurations
 BROKER = os.getenv("MQTT_BROKER", "localhost")
-PORT = int(os.getenv("MQTT_PORT", "1883"))
-KEEP_ALIVE_INTERVAL = int(os.getenv("MQTT_KEEPALIVE_INTERVAL", "60"))
+PORT = _get_int("MQTT_PORT", 1883, minimum=1, maximum=65535)
+KEEP_ALIVE_INTERVAL = _get_int("MQTT_KEEPALIVE_INTERVAL", 60, minimum=1)
 
 # Topic configurations
 VERSION = os.getenv("MQTT_VERSION", "1.0.0")
@@ -20,11 +42,11 @@ PASSWORD = os.getenv("MQTT_PASSWORD")
 
 SENSOR_TYPE = os.getenv('SENSOR_TYPE')
 
-WATER_LOW_CM = float(os.getenv("WATER_LOW_CM", 0)) or None
+WATER_LOW_CM = _get_float("WATER_LOW_CM", 0, minimum=0) or None
 
 UPPER_CAMERA_DEVICE = os.getenv("UPPER_CAMERA_DEVICE", "/dev/video0")
 LOWER_CAMERA_DEVICE = os.getenv("LOWER_CAMERA_DEVICE", "/dev/video2")
 UPPER_IMAGE_PATH = os.getenv("UPPER_IMAGE_PATH", "/tmp/upper_camera.jpg")
 LOWER_IMAGE_PATH = os.getenv("LOWER_IMAGE_PATH", "/tmp/lower_camera.jpg")
 CAMERA_RESOLUTION = os.getenv("CAMERA_RESOLUTION", "640x480")
-IMAGE_INTERVAL_SECONDS = int(os.getenv("IMAGE_INTERVAL_SECONDS", "3600"))
+IMAGE_INTERVAL_SECONDS = _get_int("IMAGE_INTERVAL_SECONDS", 3600, minimum=1)

--- a/mqtt.py
+++ b/mqtt.py
@@ -16,8 +16,8 @@ from gpiozero.pins.pigpio import PiGPIOFactory
 from app.sensors.light.light import Light
 from app.sensors.pump.pump import Pump
 from app.sensors.pcb_temp.pcb_temp import get_pcb_temperature
-from app.sensors.temperature.temperature import temperature_sensor
-from app.sensors.humidity.humidity import humidity_sensor
+from app.sensors.temperature.temperature import get_temperature_sensor
+from app.sensors.humidity.humidity import get_humidity_sensor
 from app.sensors.distance.distance import Distance, MeasurementError
 
 # Configure logging
@@ -35,17 +35,13 @@ logger = logging.getLogger(__name__)
 # set to INFO, for to capture mqtt messages at info-level messages.
 logger.setLevel(logging.WARNING)
 
-logger.debug("This is a debug message")
-logger.info("This is an info message")
-logger.warning("This is a warning message")
-logger.error("This is an error message")
-
-# Initialize devices
-pin_factory = PiGPIOFactory()
-
-pump = Pump(pin_factory=pin_factory)
-light = Light(pin_factory=pin_factory)
-distance_sensor = Distance(pin_factory=pin_factory)
+pin_factory = None
+pump = None
+light = None
+distance_sensor = None
+button = None
+client = None
+capture_lock = threading.Lock()
 
 # default on brightness
 brightness  = 50
@@ -56,10 +52,6 @@ min_per_hr  = 60
 # publish twice an hour
 publish_frequency = sec_per_min * min_per_hr / 2
 
-# Button GPIO setup using gpiozero
-button_pin = 13
-button = Button(button_pin, pin_factory=pin_factory, bounce_time=0.2, hold_time=2)  # hold_time = 2 seconds for long press detection
-
 # Variables to track the state of the light and pump
 light_state = False
 pump_state = False
@@ -67,30 +59,71 @@ double_press_time = 1  # Time to detect a double press (in seconds)
 press_count = 0
 double_press_timer = None
 
+def get_pin_factory():
+    global pin_factory
+    if pin_factory is None:
+        pin_factory = PiGPIOFactory()
+    return pin_factory
+
+def get_pump():
+    global pump
+    if pump is None:
+        pump = Pump(pin_factory=get_pin_factory())
+    return pump
+
+def get_light():
+    global light
+    if light is None:
+        light = Light(pin_factory=get_pin_factory())
+    return light
+
+def get_distance_sensor():
+    global distance_sensor
+    if distance_sensor is None:
+        distance_sensor = Distance(pin_factory=get_pin_factory())
+    return distance_sensor
+
+def configure_button_handlers():
+    global button
+    if button is None:
+        button_pin = 13
+        button = Button(button_pin, pin_factory=get_pin_factory(), bounce_time=0.2, hold_time=2)
+        button.when_pressed = handle_button_press
+
+def initialize_devices():
+    get_pump()
+    get_light()
+    get_distance_sensor()
+    configure_button_handlers()
+
 # Button press callbacks
 def toggle_light():
     global light_state
     light_state = not light_state
     if light_state:
         logger.info("Toggling Light ON")
-        light.set_duty_cycle(brightness)
-        client.publish(BASE_TOPIC + "/light/state", "ON")
+        get_light().set_duty_cycle(brightness)
+        if client is not None:
+            client.publish(BASE_TOPIC + "/light/state", "ON")
     else:
         logger.info("Toggling Light OFF")
-        light.off()
-        client.publish(BASE_TOPIC + "/light/state", "OFF")
+        get_light().off()
+        if client is not None:
+            client.publish(BASE_TOPIC + "/light/state", "OFF")
 
 def toggle_pump():
     global pump_state
     pump_state = not pump_state
     if pump_state:
         logger.info("Toggling Pump ON")
-        pump.set_speed(speed)
-        client.publish(BASE_TOPIC + "/pump/state", "ON")
+        get_pump().set_speed(speed)
+        if client is not None:
+            client.publish(BASE_TOPIC + "/pump/state", "ON")
     else:
         logger.info("Toggling Pump OFF")
-        pump.off()
-        client.publish(BASE_TOPIC + "/pump/state", "OFF")
+        get_pump().off()
+        if client is not None:
+            client.publish(BASE_TOPIC + "/pump/state", "OFF")
 
 def handle_button_press():
     global press_count, double_press_timer
@@ -116,39 +149,50 @@ def handle_single_press():
 def handle_double_press():
     toggle_pump()  # Double press toggles the pump
 
-# Set button event for press detection
-button.when_pressed = handle_button_press
-
 # helpers
 def flash_lights(times=3, delay=0.3):
-    original_brightness = light.get_brightness()  # Save the brightness (0–100 scale)
+    light_device = get_light()
+    original_brightness = light_device.get_brightness()  # Save the brightness (0–100 scale)
     was_on = original_brightness > 0  # If >0%, we consider it "on"
 
     logger.info(f"Flashing lights {times} times. Original brightness: {original_brightness}%")
 
     for _ in range(times):
-        light.off()
+        light_device.off()
         sleep(delay)
-        light.set_brightness(100)  # Flash full brightness for maximum visibility
+        light_device.set_brightness(100)  # Flash full brightness for maximum visibility
         sleep(delay)
     # Restore original state
     if was_on:
-        light.set_brightness(original_brightness)
+        light_device.set_brightness(original_brightness)
     else:
-        light.off()
+        light_device.off()
 
 def safe_distance_measure():
     global distance_sensor
     try:
-        return distance_sensor.measure_once()
+        return get_distance_sensor().measure_once()
     except MeasurementError as e:
         logger.warning(f"Distance measure failed: {e}, trying recovery")
         try:
+            if distance_sensor is not None:
+                distance_sensor.cleanup()
             distance_sensor = Distance(pin_factory=pin_factory)
             return distance_sensor.measure_once()
         except Exception as e2:
             logger.error(f"Distance full recovery failed: {e2}")
             return None
+
+def parse_percentage(payload, label):
+    try:
+        value = int(payload)
+    except (TypeError, ValueError):
+        logger.error(f"Invalid {label} value: {payload}")
+        return None
+    if not 0 <= value <= 100:
+        logger.error(f"{label} must be between 0 and 100: {value}")
+        return None
+    return value
 
 def publish_water_low_mode(client):
     if WATER_LOW_CM not in (None, 0):
@@ -359,7 +403,7 @@ def on_connect(client, userdata, flags, rc, properties=None):
     publish_water_low_mode(client)
 
 def on_message(client, userdata, msg):
-    global brightness, speed, WATER_LOW_CM
+    global brightness, speed, WATER_LOW_CM, light_state, pump_state
 
     # Handle binary payloads (like image topics) — skip decoding
     if msg.topic.endswith("/image/upper_camera") or msg.topic.endswith("/image/lower_camera"):
@@ -388,29 +432,39 @@ def on_message(client, userdata, msg):
                         return
                     else:
                         client.publish(BASE_TOPIC + "/water/low/state", "OFF", retain=True)
-                pump.set_speed(speed)
+                get_pump().set_speed(speed)
+                pump_state = True
                 client.publish(BASE_TOPIC + "/pump/state", "ON")
             elif payload.upper() == "OFF":
-                pump.off()
+                get_pump().off()
+                pump_state = False
                 client.publish(BASE_TOPIC + "/pump/state", "OFF")
 
-        elif topic_suffix == "pump/speed/set" and payload.isdigit():
-            speed = int(payload)
-            pump.set_speed(speed)
+        elif topic_suffix == "pump/speed/set":
+            parsed_speed = parse_percentage(payload, "pump speed")
+            if parsed_speed is None:
+                return
+            speed = parsed_speed
+            get_pump().set_speed(speed)
             client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
 
         # === Light Logic ===
         elif topic_suffix == "light/command":
             if payload.upper() == "ON":
-                light.set_duty_cycle(brightness)
+                get_light().set_duty_cycle(brightness)
+                light_state = True
                 client.publish(BASE_TOPIC + "/light/state", "ON")
             elif payload.upper() == "OFF":
-                light.off()
+                get_light().off()
+                light_state = False
                 client.publish(BASE_TOPIC + "/light/state", "OFF")
 
-        elif topic_suffix == "light/brightness/set" and payload.isdigit():
-            brightness = int(payload)
-            light.set_duty_cycle(brightness)
+        elif topic_suffix == "light/brightness/set":
+            parsed_brightness = parse_percentage(payload, "light brightness")
+            if parsed_brightness is None:
+                return
+            brightness = parsed_brightness
+            get_light().set_duty_cycle(brightness)
             client.publish(BASE_TOPIC + "/light/brightness/state", str(brightness))
 
         # === Water Level ===
@@ -434,10 +488,16 @@ def on_message(client, userdata, msg):
             client.publish(BASE_TOPIC + "/pcb/temperature", f"{pcb_temp:.2f}")
 
         elif topic_suffix == "temperature/get":
+            temperature_sensor = get_temperature_sensor()
+            if temperature_sensor is None:
+                raise RuntimeError("Temperature sensor is not initialized")
             temperature = temperature_sensor.read()
             client.publish(BASE_TOPIC + "/temperature", f"{temperature:.2f}")
 
         elif topic_suffix == "humidity/get":
+            humidity_sensor = get_humidity_sensor()
+            if humidity_sensor is None:
+                raise RuntimeError("Humidity sensor is not initialized")
             humidity = humidity_sensor.read()
             client.publish(BASE_TOPIC + "/humidity", f"{humidity:.2f}")
 
@@ -457,6 +517,9 @@ def publish_pcb_temperature(client):
 def publish_temperature(client):
     while True:
         try:
+            temperature_sensor = get_temperature_sensor()
+            if temperature_sensor is None:
+                raise RuntimeError("Temperature sensor is not initialized")
             temperature = temperature_sensor.read()
             logger.info(f"Publishing Temperature: {temperature:.2f}°C")
             client.publish(BASE_TOPIC + "/temperature", f"{temperature:.2f}")
@@ -467,6 +530,9 @@ def publish_temperature(client):
 def publish_humidity(client):
     while True:
         try:
+            humidity_sensor = get_humidity_sensor()
+            if humidity_sensor is None:
+                raise RuntimeError("Humidity sensor is not initialized")
             humidity = humidity_sensor.read()
             logger.info(f"Publishing Humidity: {humidity:.2f}%")
             client.publish(BASE_TOPIC + "/humidity", f"{humidity:.2f}")
@@ -482,34 +548,39 @@ def publish_water_level(client):
             client.publish(BASE_TOPIC + "/water/level", f"{distance:.2f}")
         sleep(30 * 60)
 
+def capture_images(client):
+    if not capture_lock.acquire(blocking=False):
+        logger.warning("Camera capture already in progress, skipping request")
+        return
+    try:
+        subprocess.check_call([
+            'fswebcam', '-d', UPPER_CAMERA_DEVICE, '-r', CAMERA_RESOLUTION,
+            '-S', '2', '-F', '2', '--no-banner', UPPER_IMAGE_PATH
+        ])
+        logger.info(f"Captured image from upper camera ({UPPER_CAMERA_DEVICE})")
+
+        subprocess.check_call([
+            'fswebcam', '-d', LOWER_CAMERA_DEVICE, '-r', CAMERA_RESOLUTION,
+            '-S', '2', '-F', '2', '--no-banner', LOWER_IMAGE_PATH
+        ])
+        logger.info(f"Captured image from lower camera ({LOWER_CAMERA_DEVICE})")
+
+        with open(UPPER_IMAGE_PATH, 'rb') as f:
+            upper_cam_jpeg_data = f.read()
+            client.publish(BASE_TOPIC + "/image/upper_camera", payload=upper_cam_jpeg_data, qos=0, retain=False)
+            logger.info("Published image to /image/upper_camera")
+
+        with open(LOWER_IMAGE_PATH, 'rb') as f:
+            lower_cam_jpeg_data = f.read()
+            client.publish(BASE_TOPIC + "/image/lower_camera", payload=lower_cam_jpeg_data, qos=0, retain=False)
+            logger.info("Published image to /image/lower_camera")
+    finally:
+        capture_lock.release()
+
 def publish_images(client):
     while True:
         try:
-            # Capture upper camera image
-            subprocess.check_call([
-                'fswebcam', '-d', UPPER_CAMERA_DEVICE, '-r', CAMERA_RESOLUTION,
-                '-S', '2', '-F', '2', '--no-banner', UPPER_IMAGE_PATH
-            ])
-            logger.info(f"Captured image from upper camera ({UPPER_CAMERA_DEVICE})")
-
-            # Capture lower camera image
-            subprocess.check_call([
-                'fswebcam', '-d', LOWER_CAMERA_DEVICE, '-r', CAMERA_RESOLUTION,
-                '-S', '2', '-F', '2', '--no-banner', LOWER_IMAGE_PATH
-            ])
-            logger.info(f"Captured image from lower camera ({LOWER_CAMERA_DEVICE})")
-
-            # Publish upper camera image
-            with open(UPPER_IMAGE_PATH, 'rb') as f:
-                upper_cam_jpeg_data = f.read()  # Read as raw binary
-                client.publish(BASE_TOPIC + "/image/upper_camera", payload=upper_cam_jpeg_data, qos=0, retain=False)
-                logger.info("Published image to /image/upper_camera")
-
-            # Publish lower camera image
-            with open(LOWER_IMAGE_PATH, 'rb') as f:
-                lower_cam_jpeg_data = f.read()  # Read as raw binary
-                client.publish(BASE_TOPIC + "/image/lower_camera", payload=lower_cam_jpeg_data, qos=0, retain=False)
-                logger.info("Published image to /image/lower_camera")
+            capture_images(client)
 
         except subprocess.CalledProcessError as e:
             logger.error(f"Camera capture failed: {e}")
@@ -521,11 +592,12 @@ def publish_images(client):
 
 if __name__ == "__main__":
     logger.info(f"Connecting to {BROKER} on port {PORT} with keep alive {KEEP_ALIVE_INTERVAL}")
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=f"{IDENTIFIER}_mqtt")
     client.on_connect = on_connect
     client.on_message = on_message
     client.username_pw_set(USERNAME, PASSWORD)
     client.connect(BROKER, PORT, KEEP_ALIVE_INTERVAL)
+    initialize_devices()
 
     pcb_temp_thread = threading.Thread(target=publish_pcb_temperature, args=(client,))
     pcb_temp_thread.daemon = True

--- a/mqtt.py
+++ b/mqtt.py
@@ -46,6 +46,8 @@ capture_lock = threading.Lock()
 # default on brightness
 brightness  = 50
 speed       = 100
+DEFAULT_BRIGHTNESS = 50
+DEFAULT_SPEED = 100
 sec_per_min = 60
 min_per_hr  = 60
 
@@ -432,9 +434,12 @@ def on_message(client, userdata, msg):
                         return
                     else:
                         client.publish(BASE_TOPIC + "/water/low/state", "OFF", retain=True)
+                if speed <= 0:
+                    speed = DEFAULT_SPEED
                 get_pump().set_speed(speed)
                 pump_state = True
                 client.publish(BASE_TOPIC + "/pump/state", "ON")
+                client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
             elif payload.upper() == "OFF":
                 get_pump().off()
                 pump_state = False
@@ -445,15 +450,25 @@ def on_message(client, userdata, msg):
             if parsed_speed is None:
                 return
             speed = parsed_speed
-            get_pump().set_speed(speed)
+            if speed == 0:
+                get_pump().off()
+                pump_state = False
+                client.publish(BASE_TOPIC + "/pump/state", "OFF")
+            else:
+                get_pump().set_speed(speed)
+                pump_state = True
+                client.publish(BASE_TOPIC + "/pump/state", "ON")
             client.publish(BASE_TOPIC + "/pump/speed/state", str(speed))
 
         # === Light Logic ===
         elif topic_suffix == "light/command":
             if payload.upper() == "ON":
+                if brightness <= 0:
+                    brightness = DEFAULT_BRIGHTNESS
                 get_light().set_duty_cycle(brightness)
                 light_state = True
                 client.publish(BASE_TOPIC + "/light/state", "ON")
+                client.publish(BASE_TOPIC + "/light/brightness/state", str(brightness))
             elif payload.upper() == "OFF":
                 get_light().off()
                 light_state = False
@@ -464,7 +479,14 @@ def on_message(client, userdata, msg):
             if parsed_brightness is None:
                 return
             brightness = parsed_brightness
-            get_light().set_duty_cycle(brightness)
+            if brightness == 0:
+                get_light().off()
+                light_state = False
+                client.publish(BASE_TOPIC + "/light/state", "OFF")
+            else:
+                get_light().set_duty_cycle(brightness)
+                light_state = True
+                client.publish(BASE_TOPIC + "/light/state", "ON")
             client.publish(BASE_TOPIC + "/light/brightness/state", str(brightness))
 
         # === Water Level ===

--- a/mqtt.py
+++ b/mqtt.py
@@ -42,6 +42,7 @@ distance_sensor = None
 button = None
 client = None
 capture_lock = threading.Lock()
+distance_measure_lock = threading.Lock()
 
 # default on brightness
 brightness  = 50
@@ -172,6 +173,9 @@ def flash_lights(times=3, delay=0.3):
 
 def safe_distance_measure():
     global distance_sensor
+    if not distance_measure_lock.acquire(blocking=False):
+        logger.warning("Distance measure already in progress, skipping request")
+        return None
     try:
         return get_distance_sensor().measure_once()
     except MeasurementError as e:
@@ -179,11 +183,13 @@ def safe_distance_measure():
         try:
             if distance_sensor is not None:
                 distance_sensor.cleanup()
-            distance_sensor = Distance(pin_factory=pin_factory)
+            distance_sensor = Distance(pin_factory=get_pin_factory())
             return distance_sensor.measure_once()
         except Exception as e2:
             logger.error(f"Distance full recovery failed: {e2}")
             return None
+    finally:
+        distance_measure_lock.release()
 
 def parse_percentage(payload, label):
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from flask import json
 from app import create_app
 from parameterized import parameterized
@@ -23,51 +23,53 @@ class PumpBlueprintTestCase(BaseTestCase):
     ])
 
     def test_pump_actions(self, route, mock_method, expected_message):
-        with patch(f'app.sensors.pump.routes.pump_control.{mock_method}') as mock_action:
+        mock_pump = Mock()
+        with patch('app.sensors.pump.routes.pump_control', mock_pump):
             response = self.client.post(f'{self.BASE_ROUTE}{route}')
             self.assertEqual(response.status_code, 200)
-            mock_action.assert_called_once()
+            getattr(mock_pump, mock_method).assert_called_once()
             self.assertEqual(response.get_json(), {"message": expected_message})
 
-    @patch('app.sensors.pump.routes.pump_control.on')
-    def test_pump_turn_on(self, mock_on):
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_turn_on(self, mock_pump):
         response = self.client.post(f'{self.BASE_ROUTE}/on')
         self.assertEqual(response.status_code, 200)
-        mock_on.assert_called_once()
+        mock_pump.on.assert_called_once()
         self.assertEqual(response.get_json(), {"message": "Pump turned on!"})
 
-    @patch('app.sensors.pump.routes.pump_control.off')
-    def test_pump_turn_off(self, mock_off):
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_turn_off(self, mock_pump):
         response = self.client.post(f'{self.BASE_ROUTE}/off')
         self.assertEqual(response.status_code, 200)
-        mock_off.assert_called_once()
+        mock_pump.off.assert_called_once()
         self.assertEqual(response.get_json(), {"message": "Pump turned off!"})
 
-    @patch('app.sensors.pump.routes.pump_control.set_speed')
-    def test_pump_adjust_speed(self, mock_set_speed):
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_adjust_speed(self, mock_pump):
         response = self.client.post(f'{self.BASE_ROUTE}/speed', json={"value": 50})
         self.assertEqual(response.status_code, 200)
-        mock_set_speed.assert_called_once_with(50)
+        mock_pump.set_speed.assert_called_once_with(50)
         self.assertEqual(response.get_json(), {"message": "Pump adjusted to 50% speed!"})
 
-    @patch('app.sensors.pump.routes.PumpControl.get_speed')
-    def test_pump_get_speed(self, mock_get_speed):
-        mock_get_speed.return_value = 75
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_get_speed(self, mock_pump):
+        mock_pump.get_speed.return_value = 75
         response = self.client.get(f'{self.BASE_ROUTE}/speed')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), {"value": 75})
 
     @patch('app.sensors.pump.routes.fetch_ina219_data')
-    def test_pump_get_power_data(self, mock_fetch_data):
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_get_power_data(self, mock_pump, mock_fetch_data):
         mock_data = {"current": 5.2, "voltage": 12.5}
         mock_fetch_data.return_value = mock_data
         response = self.client.get(f'{self.BASE_ROUTE}/stats')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), mock_data)
 
-    @patch('app.sensors.pump.routes.pump_control.set_speed')
-    def test_pump_adjust_speed_invalid(self, mock_set_speed):
-        mock_set_speed.side_effect = ValueError("Invalid speed value")
+    @patch('app.sensors.pump.routes.pump_control')
+    def test_pump_adjust_speed_invalid(self, mock_pump):
+        mock_pump.set_speed.side_effect = ValueError("Invalid speed value")
         response = self.client.post(f'{self.BASE_ROUTE}/speed', json={"value": 150})  # Assuming 150 is invalid
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {"message": "Invalid speed value"})
@@ -81,37 +83,37 @@ class LightBlueprintTestCase(BaseTestCase):
         self.app.config['TESTING'] = True
         self.client = self.app.test_client()
 
-    @patch('app.sensors.light.routes.light_control.on')
-    def test_light_turn_on(self, mock_on):
+    @patch('app.sensors.light.routes.light_control')
+    def test_light_turn_on(self, mock_light):
         response = self.client.post(f'{self.BASE_ROUTE}/on')
         self.assertEqual(response.status_code, 200)
-        mock_on.assert_called_once()
-        self.assertEqual(response.get_json(), {"message": "Light turned on!"})
+        mock_light.on.assert_called_once()
+        self.assertEqual(response.get_json(), {"message": "Light turned on"})
 
-    @patch('app.sensors.light.routes.light_control.off')
-    def test_light_turn_off(self, mock_off):
+    @patch('app.sensors.light.routes.light_control')
+    def test_light_turn_off(self, mock_light):
         response = self.client.post(f'{self.BASE_ROUTE}/off')
         self.assertEqual(response.status_code, 200)
-        mock_off.assert_called_once()
-        self.assertEqual(response.get_json(), {"message": "Light turned off!"})
+        mock_light.off.assert_called_once()
+        self.assertEqual(response.get_json(), {"message": "Light turned off"})
 
-    @patch('app.sensors.light.routes.light_control.set_brightness')
-    def test_light_set_brightness(self, mock_set_brightness):
+    @patch('app.sensors.light.routes.light_control')
+    def test_light_set_brightness(self, mock_light):
         response = self.client.post(f'{self.BASE_ROUTE}/brightness', json={"value": 75})
         self.assertEqual(response.status_code, 200)
-        mock_set_brightness.assert_called_once_with(75)
+        mock_light.set_brightness.assert_called_once_with(75)
         self.assertEqual(response.get_json(), {"message": "Light adjusted to 75%"})
 
-    @patch('app.sensors.light.routes.light_control.get_brightness')
-    def test_light_get_brightness(self, mock_get_brightness):
-        mock_get_brightness.return_value = 60
+    @patch('app.sensors.light.routes.light_control')
+    def test_light_get_brightness(self, mock_light):
+        mock_light.get_brightness.return_value = 60
         response = self.client.get(f'{self.BASE_ROUTE}/brightness')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), {"value": 60})
 
-    @patch('app.sensors.light.routes.light_control.set_brightness')
-    def test_light_set_brightness_invalid(self, mock_set_brightness):
-        mock_set_brightness.side_effect = ValueError("Invalid brightness value")
+    @patch('app.sensors.light.routes.light_control')
+    def test_light_set_brightness_invalid(self, mock_light):
+        mock_light.set_brightness.side_effect = ValueError("Invalid brightness value")
         response = self.client.post(f'{self.BASE_ROUTE}/brightness', json={"value": 150})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {"message": "Invalid brightness value"})
@@ -125,13 +127,13 @@ class DistanceBlueprintTestCase(BaseTestCase):
         self.app.config['TESTING'] = True
         self.client = self.app.test_client()
 
-    @patch('app.sensors.distance.routes.distance_control.measure_once')
-    def test_get_distance(self, mock_measure_once):
+    @patch('app.sensors.distance.routes.distance_control')
+    def test_get_distance(self, mock_distance):
         # Mocking the return value of measure_once method to simulate a distance value of 55.5
-        mock_measure_once.return_value = 55.5
+        mock_distance.measure_once.return_value = 55.5
 
         # Making a GET request to the /measure endpoint
-        response = self.client.get(f'{self.BASE_ROUTE}/measure')
+        response = self.client.get(f'{self.BASE_ROUTE}')
 
         # Asserting that the status code is 200 OK
         self.assertEqual(response.status_code, 200)
@@ -155,16 +157,16 @@ class PCBTempBlueprintTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Asserting that the response JSON contains the mocked temperature value
-        self.assertEqual(response.get_json(), {"pcb-temp": 55.7})
+        self.assertEqual(response.get_json(), {"pcb-temp": "55.70"})
 
 class TemperatureBlueprintTestCase(BaseTestCase):
 
     BASE_ROUTE = "/temperature"
 
-    @patch('app.sensors.temperature.routes.temperature_sensor.get_value')
-    def test_get_temperature(self, mock_get_value):
+    @patch('app.sensors.temperature.routes.load_temperature_sensor')
+    def test_get_temperature(self, mock_temperature_sensor):
         # Mocking the return value of get_value method to simulate a temperature value of 45.6
-        mock_get_value.return_value = 45.6
+        mock_temperature_sensor.return_value.read.return_value = 45.6
 
         # Making a GET request to the temperature endpoint
         response = self.client.get(f'{self.BASE_ROUTE}')
@@ -173,16 +175,16 @@ class TemperatureBlueprintTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Asserting that the response JSON contains the mocked temperature value
-        self.assertEqual(response.get_json(), {"temperature": 45.6})
+        self.assertEqual(response.get_json(), {"temperature": "45.60"})
 
 class HumidityBlueprintTestCase(BaseTestCase):
 
     BASE_ROUTE = "/humidity"
 
-    @patch('app.sensors.humidity.routes.humidity_sensor.get_value')
-    def test_get_humidity(self, mock_get_value):
+    @patch('app.sensors.humidity.routes.load_humidity_sensor')
+    def test_get_humidity(self, mock_humidity_sensor):
         # Mocking the return value of get_value method to simulate a humidity value of 45.6
-        mock_get_value.return_value = 45.6
+        mock_humidity_sensor.return_value.read.return_value = 45.6
 
         # Making a GET request to the humidity endpoint
         response = self.client.get(f'{self.BASE_ROUTE}')
@@ -191,7 +193,7 @@ class HumidityBlueprintTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Asserting that the response JSON contains the mocked humidity value
-        self.assertEqual(response.get_json(), {"humidity": 45.6})
+        self.assertEqual(response.get_json(), {"humidity": "45.60"})
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -48,5 +48,19 @@ class TestDistance(unittest.TestCase):
         measured_distance = self.distance.measure()
         self.assertAlmostEqual(measured_distance, 55.00)
 
+    @patch('app.sensors.distance.distance.DistanceSensor', autospec=True)
+    def test_cleanup_does_not_close_injected_pin_factory(self, MockDistanceSensor):
+        pin_factory = Mock()
+        distance = Distance(pin_factory=pin_factory)
+        distance.cleanup()
+        pin_factory.close.assert_not_called()
+
+    @patch('app.sensors.distance.distance.PiGPIOFactory')
+    @patch('app.sensors.distance.distance.DistanceSensor', autospec=True)
+    def test_cleanup_closes_owned_pin_factory(self, MockDistanceSensor, MockPiGPIOFactory):
+        distance = Distance()
+        distance.cleanup()
+        MockPiGPIOFactory.return_value.close.assert_called_once()
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -8,8 +8,9 @@ from app.sensors.distance.distance import Distance, MeasurementError
 
 class TestDistance(unittest.TestCase):
 
+    @patch('app.sensors.distance.distance.PiGPIOFactory')
     @patch('app.sensors.distance.distance.DistanceSensor', autospec=True)
-    def setUp(self, MockDistanceSensor):
+    def setUp(self, MockDistanceSensor, MockPiGPIOFactory):
         # Mock the behavior of the DistanceSensor so it returns some fixed values
         self.mock_sensor = MockDistanceSensor.return_value
         self.mock_sensor.distance = 0.5


### PR DESCRIPTION
## Summary
- lazy-initialize GPIO/I2C-backed Flask route sensors and MQTT hardware devices
- validate numeric config values and bound MQTT percentage commands
- remove startup log noise, guard camera captures, and update tests to run without Pi hardware